### PR TITLE
Don't crash when config is nil; Fixes #4

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -61,6 +61,7 @@ Puppet::Type.type(:repository).provide :git do
   end
 
   def friendly_config
+    return if @resource[:config].nil?
     @friendly_config ||= Array.new.tap do |a|
       @resource[:config].each do |setting, value|
         a << "-c #{setting}=#{value}"


### PR DESCRIPTION
Without this early return, a nil `@resource[:config]` would raise NoMethodError when friendly_config tried to iterate using `#each`. See #4 for an example.
