### PR TITLE
join the command into a string before executing

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:repository).provide :git do
       friendly_extra,
       friendly_source,
       friendly_path
-    ].flatten.compact
+    ].flatten.compact.join(' ')
 
     execute command, command_opts
   end


### PR DESCRIPTION
In a nutshell, `exec` blows up when you pass an array containing elements with spaces in them. This can come up when giving the `extra` arg:

``` puppet
repository { "/tmp/repo":
  source  => "whatever/stuff",
  extra   => "-b my_cool_branch"
}
```

See boxen/puppet-ruby#19 for wayyyyy more detail.
