### PR TITLE
Allow use of this module without boxen

### DIFF
--- a/lib/puppet/type/repository.rb
+++ b/lib/puppet/type/repository.rb
@@ -105,6 +105,13 @@ Puppet.newtype :repository do
           "You must specify a source for Repository[#{self[:name]}]"
       end
     end
+
+    if self[:user].nil?
+      unless self[:ensure] == :absent || self[:ensure] == 'absent'
+        raise Puppet::Error, \
+          "You must specify a user for Repository[#{self[:name]}]"
+      end
+    end
   end
 
   def exists?

--- a/spec/unit/puppet/type/repository_spec.rb
+++ b/spec/unit/puppet/type/repository_spec.rb
@@ -82,9 +82,6 @@ describe Puppet::Type.type(:repository) do
     end
 
     it "should default to boxen_user if it exists" do
-      Facter[:boxen_user].stubs(:value).returns(nil)
-      factory.call(default_opts)[:user].should == nil
-
       Facter[:boxen_user].stubs(:value).returns('testuser')
       factory.call(default_opts)[:user].should == 'testuser'
     end
@@ -94,6 +91,14 @@ describe Puppet::Type.type(:repository) do
 
       opts = default_opts.merge(:user => "otheruser")
       factory.call(opts)[:user].should == 'otheruser'
+    end
+
+    it "requires a user if boxen_user doesn't exist" do
+      Facter[:boxen_user].stubs(:value).returns(nil)
+
+      expect {
+        factory.call(default_opts)
+      }.to raise_error(Puppet::Error, /You must specify a user/)
     end
   end
 


### PR DESCRIPTION
I'd like to use this puppet module without Boxen. It appears that the only dependency on Boxen for use with normal Puppet is the lack of a `boxen_user` fact. So I fixed it to throw an error if the `boxen_user` fact isn't available.

Thanks! :heart:
