### PR TITLE
Add support for changing the origin's URL automatically.

### DIFF
--- a/lib/puppet/provider/repository/git.rb
+++ b/lib/puppet/provider/repository/git.rb
@@ -52,6 +52,20 @@ Puppet::Type.type(:repository).provide :git do
     execute command, command_opts
   end
 
+  def ensure_remote
+    create unless cloned?
+
+    Dir.chdir @resource[:path] do
+      source = execute [command(:git), "config", "--get", "remote.origin.url"], command_opts
+
+      if source != friendly_source
+        execute [command(:git), "config", "--set", "remote.origin.url", friendly_source], command_opts
+
+        Puppet.info("Repository[#{@resource[:name]}] changing source from #{source} to #{friendly_source}")
+      end
+    end
+  end
+
   def ensure_revision
     create unless cloned?
 

--- a/lib/puppet/type/repository.rb
+++ b/lib/puppet/type/repository.rb
@@ -12,6 +12,7 @@ Puppet.newtype :repository do
     end
 
     newvalue /./ do
+      provider.ensure_remote
       provider.ensure_revision
     end
 


### PR DESCRIPTION
The idea is that if we change the `source` option (from `org/repo` to `fork/repo`) then puppet will figure out automatically how to change the remote URL's on its own without developers having to write anything to handle this.

I haven't tested this locally yet since I'm having a hard time groking on how to use the local repo with the boxen setup but I definitely want to take a spin on this locally before getting it merged.